### PR TITLE
fix: falsyなAPIリクエストボディを保持する

### DIFF
--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { apiClient } from '../client'
+
+describe('apiClient', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it.each([
+    ['zero', 0, '0'],
+    ['false', false, 'false'],
+    ['empty string', '', '""'],
+    ['null', null, 'null'],
+  ])('serializes a %s request body', async (_name, body, expectedBody) => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 204 })
+    )
+
+    await apiClient('/test', {
+      method: 'POST',
+      body,
+    })
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect(fetchMock.mock.calls[0]?.[1]?.body).toBe(expectedBody)
+  })
+
+  it('omits the request body when it is undefined', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 204 })
+    )
+
+    await apiClient('/test', { method: 'POST' })
+
+    expect(fetchMock.mock.calls[0]?.[1]?.body).toBeUndefined()
+  })
+})

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -126,7 +126,7 @@ export async function apiClient<T>(
       ...authHeaders,
       ...headers,
     },
-    body: body ? JSON.stringify(body) : undefined,
+    body: body === undefined ? undefined : JSON.stringify(body),
     ...restOptions,
   })
 
@@ -197,4 +197,3 @@ export async function apiPut<T, B = unknown>(
 export async function apiDelete<T>(endpoint: string): Promise<T> {
   return apiClient<T>(endpoint, { method: 'DELETE' })
 }
-


### PR DESCRIPTION
## 変更内容
- APIクライアントのリクエストボディ判定を truthy 判定から `undefined` 判定へ変更
- `0`、`false`、空文字、`null` がJSONとして正しく送信されることを回帰テストで保証
- `undefined` の場合は従来どおりボディを省略

## 背景
従来の `body ? JSON.stringify(body) : undefined` では、値として有効な `0`、`false`、空文字が falsy と評価され、リクエストボディ自体が欠落していました。数値や真偽値を直接送るAPIを追加した際に意図しない入力欠落が発生するため、ボディの有無を `undefined` のみで判定します。

## 影響
オブジェクト形式の既存リクエストには影響せず、プリミティブ値を送る場合の挙動のみ正しくなります。

## 検証
- Vitestの回帰テストを追加
- ブランチ差分が `main` に対して2コミット、2ファイルであることを確認

※ GitHubコネクタ経由で変更したため、ローカル実行によるテスト・ビルド確認は未実施です。